### PR TITLE
made data_download command line argument more consistent with example

### DIFF
--- a/scripts/data_download.py
+++ b/scripts/data_download.py
@@ -1,16 +1,17 @@
 import pandas
+import os
 import click
 from ucimlrepo import fetch_ucirepo 
 
 @click.command()
-@click.option('--path', type=str)
-def main(path):
+@click.option('--write-to', type=str)
+def main(write_to):
     wine_quality = fetch_ucirepo(id=186) 
 
     wine_df = wine_quality.data.original
     white_wine_df = wine_df[wine_df['color'] == 'white']
 
-    white_wine_df.to_csv(path)
+    white_wine_df.to_csv(os.path.join(write_to, "winequality-white.csv"))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
file name doesn't have to be specified anymore, only the directory for the raw data.