### PR TITLE
package issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .jupyter/
 .local/
 .npm/
+.ipynb_checkpoints/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,12 @@ RUN /opt/conda/envs/dsci522project/bin/python -m ipykernel install --user --name
 # Expose JupyterLab port
 EXPOSE 8888
 
+# Make dsci522project the default environment
+RUN echo "conda activate dsci522project" >> ~/.bashrc
+
+# Set environment variables so the environment is active by default
+ENV PATH /opt/conda/envs/dsci522project/bin:$PATH
+
 # Start JupyterLab from the dsci522project environment
 CMD ["bash", "-c", "source /opt/conda/etc/profile.d/conda.sh && conda activate dsci522project && jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     ports:
       - "8888:8888"
     volumes:
-     - ./:/jovyan
-    working_dir: /jovyan
+     - ./:/workplace
+    working_dir: /workplace
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Docker container opens in your base environment and not the project environment
- added RUN echo ... so that the conda environment is automatically active
- added ENV PATH ... so commands like pip etc. are installed in the project environment not base

Docker-compose edits
- changed /jovyan to /workplace to match Dockerfile