### PR TITLE
added default to --write-to argument in data download script

### DIFF
--- a/scripts/data_download.py
+++ b/scripts/data_download.py
@@ -4,7 +4,7 @@ import click
 from ucimlrepo import fetch_ucirepo 
 
 @click.command()
-@click.option('--write-to', type=str)
+@click.option('--write-to', default='data/raw', help='Directory for data to be downloaded to')
 def main(write_to):
     wine_quality = fetch_ucirepo(id=186) 
 


### PR DESCRIPTION
The following change was made to data_download.py
- made default path for --write to argument data/raw